### PR TITLE
Update of AWI CryoSat-2 v2.1 L3 processor settings

### DIFF
--- a/pysiral/resources/pysiral-cfg/proc/l3/l3c_awi_v2p1.yaml
+++ b/pysiral/resources/pysiral-cfg/proc/l3/l3c_awi_v2p1.yaml
@@ -117,9 +117,11 @@ l2_parameter:
 # the prefilter will apply a nan mask from a specified parameter to other parameters
 
 l2i_prefilter:
-    active: False
-    nan_source: Null
-    nan_targets: Null
+    active: True
+    nan_source: sea_ice_thickness
+    nan_targets:
+        - freeboard
+        - radar_freeboard
 
 # ==================================================
 # Level-3 Parameter


### PR DESCRIPTION
Added l2i pre-filtering to the AWI CryoSat-2 v2.1 Level-3 processor settings. To confusing to have radar freeboard over leads