### PR TITLE
Fix for macos segv

### DIFF
--- a/pysiral/bnfunc/cytfmra.pyx
+++ b/pysiral/bnfunc/cytfmra.pyx
@@ -21,7 +21,7 @@ ctypedef np.float32_t DTYPE_tf
 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)
+@cython.wraparound(True)
 @cython.nonecheck(False)
 def cytfmra_findpeaks(np.ndarray[DTYPE_t, ndim=1] data):
     """


### PR DESCRIPTION
Spotted warning message:
warning: pysiral/bnfunc/cytfmra.pyx:45:25: the result of using negative indices inside of code sections marked as 'wraparound=False' is undefined

Resolving this by setting wraparound=True for cytfmra_findpeaks() resolves the SEGV experienced when running L1 processing under macOS.