### PR TITLE
Updates to the ML-based retracking routines

### DIFF
--- a/pysiral/resources/pysiral-cfg/proc/l2/cciplus/cci_envisat_nh_v3p0-rc1.yaml
+++ b/pysiral/resources/pysiral-cfg/proc/l2/cciplus/cci_envisat_nh_v3p0-rc1.yaml
@@ -1,6 +1,6 @@
 # Level-2 processor settings for CCI+ Northern hemisphere CRDP v3.0-preview-1
 metadata:
-    label: "ESA CCI+ Envisat reprocessed northern hemisphere sea-ice thickness climate data record - Spring 2022 RC1 (former preview5-v8)"
+    label: "ESA CCI+ Envisat reprocessed northern hemisphere sea-ice thickness climate data record - Spring 2022 RC1 (former preview5-v9)"
     product_line: cci
     record_type: tds
     platform: envisat
@@ -61,8 +61,8 @@ auxdata:
                 # The id and name of the parameter added to the level-2 object
                 output_parameter: [tfmrathrs_iml, tfmra_threshold_iceml]
                 # File basename of the trained model data
-                model_file: snn_cci_envisat_nh_v3p0-rc1.pth
-                torch_class: TorchFunctionalWaveformModelSNN
+                model_file: fnn_cci_envisat_nh_v3p0-rc1.pth
+                torch_class: TorchFunctionalWaveformModelFNN
                 input_neurons: 45
                 # The model may predict non-sense threshold values. Limit
                 # to a normal range

--- a/pysiral/resources/pysiral-cfg/proc/l2/cciplus/cci_ers2_nh_v3p0-rc1.yaml
+++ b/pysiral/resources/pysiral-cfg/proc/l2/cciplus/cci_ers2_nh_v3p0-rc1.yaml
@@ -1,6 +1,6 @@
 # Level-2 processor settings for CCI+ Northern hemisphere CRDP v3.0-preview-1
 metadata:
-    label: "ESA CCI+ ERS-2 reprocessed northern hemisphere sea-ice thickness climate data record - Rework May 2022 (former preview5-v7)"
+    label: "ESA CCI+ ERS-2 reprocessed northern hemisphere sea-ice thickness climate data record - Rework May 2022"
     product_line: cci
     record_type: tds
     platform: ers2
@@ -61,8 +61,8 @@ auxdata:
                 # The id and name of the parameter added to the level-2 object
                 output_parameter: [tfmrathrs_iml, tfmra_threshold_iceml]
                 # File basename of the trained model data
-                model_file: snn_cci_ers2_nh_v3p0-rc1.path
-                torch_class: TorchFunctionalWaveformModelSNN
+                model_file: fnn_cci_ers2_nh_v3p0-rc1.pth
+                torch_class: TorchFunctionalWaveformModelFNN
                 input_neurons: 35
                 # The model may predict non-sense threshold values. Limit
                 # to a normal range


### PR DESCRIPTION
Changes to the ml.py were necessary due to coding error in the computation of the first-maximum index that is necessary for the correct setup for the sub-waveform retracking. This made changes to the respective RC-1 models and their setting files necessary.