### PR TITLE
 Replacing attrdict.AttrDict with internal implementation (break lock to python 3.9)

### DIFF
--- a/pysiral/__init__.py
+++ b/pysiral/__init__.py
@@ -26,9 +26,10 @@ from pathlib import Path
 from typing import Iterable, Union
 
 import yaml
-from attrdict import AttrDict
 from dateperiods import DatePeriod
 from loguru import logger
+
+from pysiral.core.legacy_classes import AttrDict
 
 warnings.filterwarnings("ignore")
 
@@ -103,10 +104,12 @@ class _MissionDefinitionCatalogue(object):
         with open(str(self._filepath)) as fh:
             self._content = AttrDict(yaml.safe_load(fh))
 
-    def get_platform_info(self, platform_id):
+    def get_platform_info(self, platform_id) -> Union[AttrDict, None]:
         """
         Return the full configuration attr dict for a given platform id
+
         :param platform_id:
+
         :return:
         """
         platform_info = self._content.platforms.get(platform_id, None)

--- a/pysiral/auxdata/__init__.py
+++ b/pysiral/auxdata/__init__.py
@@ -26,7 +26,7 @@ from typing import List
 
 import numpy as np
 import scipy.ndimage as ndimage
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from pyproj import Proj
 
 from pysiral import import_submodules

--- a/pysiral/core/__init__.py
+++ b/pysiral/core/__init__.py
@@ -7,7 +7,7 @@ __author__ = "Stefan Hendricks"
 
 __all__ = [
     "class_template", "clocks", "config", "datahandler", "errorhandler",
-    "flags", "helper", "iotools", "output",
+    "flags", "helper", "iotools", "legacy_classes.py", "output",
     "DefaultLoggingClass", "functions"
 ]
 

--- a/pysiral/core/config.py
+++ b/pysiral/core/config.py
@@ -15,12 +15,12 @@ Created on Mon Jul 06 10:38:41 2015
 @author: Stefan
 """
 
+import yaml
+
 from pathlib import Path
 from typing import Dict, Union
 
-import yaml
-from attrdict import AttrDict
-
+from pysiral.core.legacy_classes import AttrDict
 from pysiral import psrlcfg
 
 

--- a/pysiral/core/datahandler.py
+++ b/pysiral/core/datahandler.py
@@ -11,7 +11,7 @@ from itertools import product
 from pathlib import Path
 from typing import List, Union
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from dateperiods import DatePeriod
 from dateutil.relativedelta import relativedelta
 from loguru import logger

--- a/pysiral/core/legacy_classes.py
+++ b/pysiral/core/legacy_classes.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module provides access to deprecated legacy classes and functions that are still used in some parts of the codebase.
+These classes and functions are maintained for backward compatibility but should not be used in new development.
+"""
+
+__author__ = "Stefan Hendricks <stefan.hendricks@awi.de>"
+
+
+from collections import UserDict
+
+
+class AttrDict(UserDict):
+    """
+    Short implementation of attrdict.AttrDict using UserDict. The code is based on the solutions shared here
+    https://stackoverflow.com/a/76231823 and has been modified to allow nestesd AttrDict instances.
+    """
+
+    def __getattr__(self, key):
+        item = self.__getitem__(key)
+        return AttrDict(**item) if isinstance(item, dict) else item
+
+    def __setattr__(self, key, value):
+        if key == "data":
+            return super().__setattr__(key, value)
+        return self.__setitem__(key, value)

--- a/pysiral/core/output.py
+++ b/pysiral/core/output.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import cftime
 import numpy as np
 import parse
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from dateutil import parser as dtparser
 from loguru import logger
 from netCDF4 import Dataset, date2num

--- a/pysiral/cryosat2/functions.py
+++ b/pysiral/cryosat2/functions.py
@@ -12,7 +12,7 @@ import numpy as np
 import numpy.typing as npt
 import parse
 import xmltodict
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from dateutil import parser as dtparser
 from loguru import logger
 

--- a/pysiral/envisat/l1_adapter.py
+++ b/pysiral/envisat/l1_adapter.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Union
 
 import numpy as np
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from cftime import num2pydate
 from loguru import logger
 from scipy import interpolate

--- a/pysiral/grid.py
+++ b/pysiral/grid.py
@@ -11,7 +11,7 @@ from typing import Any, Tuple, Union
 import numpy as np
 import numpy.typing as npt
 import scipy.ndimage as ndimage
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from pyproj import Proj
 from pyresample import geometry
 

--- a/pysiral/l1preproc/__init__.py
+++ b/pysiral/l1preproc/__init__.py
@@ -15,7 +15,7 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 import numpy as np
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from dateperiods import DatePeriod, PeriodIterator
 from geopy import distance
 from loguru import logger

--- a/pysiral/l1preproc/procitems.py
+++ b/pysiral/l1preproc/procitems.py
@@ -52,7 +52,7 @@ are currently implemented:
 
 from typing import Any, Dict, List, TypeVar, Union
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from schema import And, Schema
 
 from pysiral import get_cls

--- a/pysiral/retracker/__init__.py
+++ b/pysiral/retracker/__init__.py
@@ -10,7 +10,7 @@ import time
 from typing import Dict
 
 import numpy as np
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral.core.flags import FlagContainer

--- a/pysiral/surface.py
+++ b/pysiral/surface.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from typing import List, Tuple, Union
 
 import numpy as np
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral.core.config import RadarModes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 astropy
-attrdict
 bottleneck
 cartopy
 cftime

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ Testing the pysiral configuration management
 import unittest
 from pathlib import Path
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_definition_files.py
+++ b/tests/test_definition_files.py
@@ -9,7 +9,7 @@ import datetime
 import unittest
 from pathlib import Path
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_l1_proc_def_files.py
+++ b/tests/test_l1_proc_def_files.py
@@ -10,7 +10,7 @@ Level2Processor conventions
 
 import unittest
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_l2_ouput_def_files.py
+++ b/tests/test_l2_ouput_def_files.py
@@ -10,7 +10,7 @@ Level2Processor conventions
 
 import unittest
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_l2_proc_def_files.py
+++ b/tests/test_l2_proc_def_files.py
@@ -9,7 +9,7 @@ Level2Processor conventions
 import unittest
 
 import yaml
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_l3_ouput_def_files.py
+++ b/tests/test_l3_ouput_def_files.py
@@ -10,7 +10,7 @@ Level2Processor conventions
 
 import unittest
 
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg

--- a/tests/test_l3_proc_def_files.py
+++ b/tests/test_l3_proc_def_files.py
@@ -9,7 +9,7 @@ Level2Processor conventions
 import unittest
 
 import yaml
-from attrdict import AttrDict
+from pysiral.core.legacy_classes import AttrDict
 from loguru import logger
 
 from pysiral import psrlcfg


### PR DESCRIPTION
The package `attrdict` (https://github.com/bcj/AttrDict) is no longer maintained and does not support python versions beyond 3.9. It is however used for all pysiral configuration data and thus blocks running pysiral with newer python versions. 

The limited functionality of `attrdict.AttrDict` needed for pysiral can also be achieved using an minor modification of `collections.UserDict` which is added to the pysiral code base. 

All references to the deprecated package are new removed. 

The functionality of the new implementation has been tested with: 


```python
from collections import UserDict


class AttrDict(UserDict):

    def __getattr__(self, key):
        item = self.__getitem__(key)
        return AttrDict(**item) if isinstance(item, dict) else item

    def __setattr__(self, key, value):
        if key == "data":
            return super().__setattr__(key, value)
        return self.__setitem__(key, value)


# Example usage and tests for AttrDict
test_dict = {
    "key1": "value1",
    "key2": 42,
    "key3": [1, 2, 3],
    "key4": True,
    "key5": None,
    "key6": {"nested_key": "nested_value"},
    "key7": {"sub_key": {"sub_sub_key": "sub_sub_key_value"}},

}

a = AttrDict(**test_dict)

assert a.key1 == "value1"
assert a.key2 == 42
assert a.key3 == [1, 2, 3]
assert a.key4 is True
assert a.key5 is None

assert isinstance(a.key6, AttrDict)
assert a.key6.nested_key == "nested_value"

assert isinstance(a.key7.sub_key, AttrDict)
assert a.key7.sub_key.sub_sub_key == "sub_sub_key_value"

a.test = "test_value"
assert a.test == "test_value"
a["test2"] = "test_value2"
assert a["test2"] == "test_value2"

a["test3"] = {"sub_key": "sub_value"}
assert isinstance(a.test3, AttrDict)
```