### PR TITLE
Feature/logger refactoring

### DIFF
--- a/pysiral/__init__.py
+++ b/pysiral/__init__.py
@@ -4,22 +4,21 @@
 pysiral is the PYthon Sea Ice Radar ALtimetry toolbox
 """
 
-__all__ = ["auxdata", "cryosat2", "envisat", "ers", "sentinel3",
+__all__ = [ "_logger", "auxdata", "cryosat2", "envisat", "ers", "sentinel3",
            "filter", "frb", "grid",
            "l1data", "l1preproc", "l2data", "l2preproc", "l2proc", "l3proc",
            "mask", "proj", "retracker",
            "sit", "surface", "waveform", "psrlcfg", "import_submodules", "get_cls",
-           "set_psrl_cpu_count", "InterceptHandler", "__version__"]
+           "set_psrl_cpu_count", "__version__"]
 
 import importlib
-import logging
+
 import multiprocessing
 import pkgutil
 import shutil
 import socket
 import subprocess
 import sys
-import warnings
 from datetime import datetime
 from distutils import dir_util
 from pathlib import Path
@@ -29,35 +28,9 @@ import yaml
 from dateperiods import DatePeriod
 from loguru import logger
 
+
+import pysiral._logger
 from pysiral.core.legacy_classes import AttrDict
-
-warnings.filterwarnings("ignore")
-
-# Set standard logger format
-logger.remove()
-fmt = '<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | ' + \
-      '<level>{level: <8}</level> | ' + \
-      '<cyan>{name: <25}</cyan> | ' + \
-      '<cyan>L{line: <5}</cyan> | ' + \
-      '<level>{message}</level>'
-logger.add(sys.stderr, format=fmt, enqueue=True)
-
-
-class InterceptHandler(logging.Handler):
-    def emit(self, record):
-        # Get corresponding Loguru level if it exists
-        try:
-            level = logger.level(record.levelname).name
-        except ValueError:
-            level = record.levelno
-
-        # Find caller from where originated the logged message
-        frame, depth = logging.currentframe(), 2
-        while frame.f_code.co_filename == logging.__file__:
-            frame = frame.f_back
-            depth += 1
-
-        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 # Get version from VERSION in package root
@@ -75,6 +48,7 @@ except IOError:
 __version__ = version
 __author__ = "Stefan Hendricks"
 __author_email__ = "stefan.hendricks@awi.de"
+
 
 # Get git version (allows tracing of the exact commit)
 # TODO: This only works when the code is in a git repository (and not as installed python package)
@@ -735,7 +709,7 @@ def get_cls(module_name, class_name, relaxed=True):
         if relaxed:
             return None, e
         else:
-            raise NotImplementedError(f"Cannot load class: {module_name}.{class_name}") from exc
+            raise NotImplementedError(f"Cannot load class: {module_name}.{class_name}") from e
 
 
 def import_submodules(package, recursive=True):

--- a/pysiral/__init__.py
+++ b/pysiral/__init__.py
@@ -9,7 +9,7 @@ __all__ = [ "_logger", "auxdata", "cryosat2", "envisat", "ers", "sentinel3",
            "l1data", "l1preproc", "l2data", "l2preproc", "l2proc", "l3proc",
            "mask", "proj", "retracker",
            "sit", "surface", "waveform", "psrlcfg", "import_submodules", "get_cls",
-           "set_psrl_cpu_count", "__version__"]
+           "set_psrl_cpu_count", "__version__", "__software_version__"]
 
 import importlib
 
@@ -17,7 +17,6 @@ import multiprocessing
 import pkgutil
 import shutil
 import socket
-import subprocess
 import sys
 from datetime import datetime
 from distutils import dir_util
@@ -49,14 +48,9 @@ __version__ = version
 __author__ = "Stefan Hendricks"
 __author_email__ = "stefan.hendricks@awi.de"
 
-
 # Get git version (allows tracing of the exact commit)
-# TODO: This only works when the code is in a git repository (and not as installed python package)
-try:
-    __software_version__ = subprocess.check_output(["git", "log", "--pretty=format:%H", "-n", "1"])
-    __software_version__ = __software_version__.strip().decode("utf-8")
-except (FileNotFoundError, subprocess.CalledProcessError):
-    __software_version__ = None
+# TODO: Implement git version retrieval with git hooks (server-side post receive hook)
+__software_version__ = None
 
 
 class _MissionDefinitionCatalogue(object):

--- a/pysiral/_logger.py
+++ b/pysiral/_logger.py
@@ -52,9 +52,9 @@ def logger_format(record: Dict) -> str:
     """
     elapsed_timestr = get_duration(record["elapsed"].total_seconds())
     fmt_str = (
-        '<green>{time:YYYY-MM-DD HH:mm:ss.SS} - {elapsed_timestr}</green>  | '
+        '<green>{time:YYYY-MM-DD HH:mm:ss.SS} - {elapsed_timestr}</green> | '
         '<level>{level:<8}</level> | '
-        '<level>{message}</level>\n'
+        '<level>{message} </level>\n'
     )
     return fmt_str.format(elapsed_timestr=elapsed_timestr, **record)
 

--- a/pysiral/_logger.py
+++ b/pysiral/_logger.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+"""
+A small module to handle logging in pysiral. This module is intended to be the first module
+called in pysiral.__init__.py, so that the logger is set up before any other modules are imported.
+"""
+
+import os
+import sys
+import logging
+import warnings
+from loguru import logger
+from typing import Dict
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+
+class InterceptHandler(logging.Handler):
+
+    def emit(self, record):
+        # Get corresponding Loguru level if it exists
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find caller from where originated the logged message
+        frame, depth = logging.currentframe(), 2
+        while frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+def get_duration(elapsed_seconds: int, fmt_str: str = "%H:%M:%S") -> str:
+    """
+    Get a formatted string representing the duration from a given number of elapsed seconds.
+    """
+    datum = datetime(1900, 1, 1)
+    duration = datum + relativedelta(seconds=elapsed_seconds)
+    return duration.strftime(fmt_str)
+
+
+def logger_format(record: Dict) -> str:
+    """
+    Formatter function for loguru (Normal mode
+
+    :param record:
+
+    :return: logger string
+    """
+    elapsed_timestr = get_duration(record["elapsed"].total_seconds())
+    fmt_str = (
+        '<green>{time:YYYY-MM-DD HH:mm:ss.SS} - {elapsed_timestr}</green>  | '
+        '<level>{level:<8}</level> | '
+        '<level>{message}</level>\n'
+    )
+    return fmt_str.format(elapsed_timestr=elapsed_timestr, **record)
+
+
+def logger_format_debug(record: Dict) -> str:
+    elapsed_timestr = get_duration(record["elapsed"].total_seconds())
+    if record["function"] == "<module>":
+        record["function"] = ""
+    else:
+        record["function"] = "." + record["function"]
+    code_line = "{name}{function}:L{line}".format(**record)
+    fmt_str = (
+        '<green>{time:YYYY-MM-DD HH:mm:ss.SS} - {elapsed_timestr}</green> | '
+        '<level>{level: <8}</level> | '
+        '<cyan>{code_line}</cyan> : '
+        '<level>{message}</level>\n'
+    )
+    return fmt_str.format(elapsed_timestr=elapsed_timestr, code_line=code_line, **record)
+
+
+def set_logger() -> None:
+    """
+    Set up the logger for pysiral.
+    """
+    logger.remove()
+    debug_mode = "PYSIRAL_DEBUG_LOGGER" in os.environ
+    log_level = "DEBUG" if debug_mode else "INFO"
+    logger_format_func = logger_format_debug if debug_mode else logger_format
+    logger.add(sys.stderr, format=logger_format_func, enqueue=True, level=log_level)
+
+
+# Suppress warnings
+warnings.filterwarnings("ignore")
+
+
+set_logger()
+
+

--- a/pysiral/retracker/samosa.py
+++ b/pysiral/retracker/samosa.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     SAMOSA_OK = False
 
-from pysiral import InterceptHandler
+from pysiral._logger import InterceptHandler
 from pysiral.retracker import BaseRetracker
 
 # TODO: Move this to an environment variable?

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cartopy
 cftime
 cython
 dateperiods @ git+https://github.com/pysiral/dateperiods.git@main#egg=dateperiods
-dateutil
 dateutils
 flake8
 geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cartopy
 cftime
 cython
 dateperiods @ git+https://github.com/pysiral/dateperiods.git@main#egg=dateperiods
+dateutil
 dateutils
 flake8
 geopandas


### PR DESCRIPTION
Move the logging setup to a small module that is called first. The default log level now is INFO (was DEBUG). The DEBUG level can be (re)activated by setting the environmental variable `PYSIRAL_DEBUG_LOGGER` to any value. 

Also remove the estimation of software version in pysiral.__init__. This functionality is supposed to be implemented with server side git hooks. 